### PR TITLE
Include raw file size in tasks.

### DIFF
--- a/src/hooks/use-uploader.ts
+++ b/src/hooks/use-uploader.ts
@@ -133,6 +133,7 @@ export function useUploader<Result = any>({
           progress: 0,
           status: Uploading,
           formattedSize: Utils.formatFileSize(file.size),
+          size: file.size,
           meta
         }
         addTask(newTask);
@@ -152,6 +153,7 @@ export function useUploader<Result = any>({
         progress: 0,
         status: Uploading,
         formattedSize: Utils.formatFileSize(filesSize),
+        size: filesSize,
         meta
       }
       addTask(newTask);

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type Task<A = any> = {
   progress: number;
   status: UploadStatus;
   formattedSize: string;
+  size: number;
   meta?: { [key: string]: any };
   result?: TaskResult<A>;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -47,6 +47,7 @@ it('sucessfully uploaded a file', async () => {
     key2: "value2"
   });
   expect(result.current[0][0].formattedSize).toEqual('12 B');
+  expect(result.current[0][0].size).toEqual(12)
   expect(result.current[0][0].progress).toEqual(25);
   expect(result.current[0][0].status).toEqual(Uploading);
 
@@ -102,6 +103,7 @@ it('stop uploading process', async () => {
     key2: "value2"
   });
   expect(result.current[0][0].formattedSize).toEqual('12 B');
+  expect(result.current[0][0].size).toEqual(12)
   expect(result.current[0][0].progress).toEqual(25);
   expect(result.current[0][0].status).toEqual(Uploading);
 
@@ -150,6 +152,7 @@ it('uploaded failed', async () => {
     key2: "value2"
   });
   expect(result.current[0][0].formattedSize).toEqual('12 B');
+  expect(result.current[0][0].size).toEqual(12)
   expect(result.current[0][0].status).toEqual(Failed);
   expect(result.current[0][0].result).toEqual({
     httpStatus: 401,


### PR DESCRIPTION
This is a useful value to have when you'd like to format values differently or sum many values before formatting.