### PR TITLE
Update failed task with full error details

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestHeaders, Method } from "axios";
+import { AxiosError, AxiosRequestHeaders, Method } from "axios";
 
 export const Uploading = "uploading";
 export const Stopped = "stopped";
@@ -17,6 +17,7 @@ export type UploadParams = {
 export type TaskResult<A = any> = {
   httpStatus: number | undefined;
   responseData: A | undefined;
+  error?: AxiosError<A> | Error | undefined;
 }
 
 export type Task<A = any> = {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -65,6 +65,7 @@ it('sucessfully uploaded a file', async () => {
     }
   });
 
+  expect(result.current[0][0].result?.error).toBeUndefined();
 });
 
 it('stop uploading process', async () => {
@@ -155,6 +156,14 @@ it('uploaded failed', async () => {
   expect(result.current[0][0].size).toEqual(12)
   expect(result.current[0][0].status).toEqual(Failed);
   expect(result.current[0][0].result).toEqual({
+    error: {
+      response: {
+        data: {
+            message: "unauthorized",
+        },
+        status: 401,
+      },
+    },
     httpStatus: 401,
     responseData: {
       message: 'unauthorized'


### PR DESCRIPTION
It's useful to know what the error was for providing good error messages. I would have liked to have just had the axios result vs axios error as a whole stored on the task but this maintains backwards compatibility while enabling the new functionality.

Co-authored-by: Matt Florence <matt@mattflo.com>